### PR TITLE
Adding ollama convertor

### DIFF
--- a/tools/ollama/convert-models-to-ui.ps1
+++ b/tools/ollama/convert-models-to-ui.ps1
@@ -1,3 +1,9 @@
+# Check if ollama command is available
+if (-Not (Get-Command ollama -ErrorAction SilentlyContinue)) {
+    Write-Host "Ollama command not found. Please ensure Ollama is installed and in PATH."
+    exit 1
+}
+
 # Paths
 $modelsRoot = "$env:USERPROFILE\.ollama\models"
 $manifestPath = Join-Path $modelsRoot "manifests"

--- a/tools/ollama/convert-models-to-ui.ps1
+++ b/tools/ollama/convert-models-to-ui.ps1
@@ -1,0 +1,63 @@
+# Paths
+$modelsRoot = "$env:USERPROFILE\.ollama\models"
+$manifestPath = Join-Path $modelsRoot "manifests"
+$logFile = Join-Path $modelsRoot "model_registration.log"
+
+# Default Modelfile content
+$defaultParams = @"
+PARAMETER temperature 0.7
+PARAMETER top_p 0.9
+PARAMETER num_ctx 4096
+
+TEMPLATE """
+{{ .Prompt }}
+"""
+"@
+
+# Start logging
+"=== Ollama Model Registration Log ===" | Out-File $logFile
+
+# Get all model names from manifests
+$modelNames = Get-ChildItem -Path $manifestPath -File | ForEach-Object {
+    $_.BaseName
+}
+
+Write-Host "Found models: $($modelNames -join ', ')"
+
+foreach ($model in $modelNames) {
+    try {
+        $modelFolder = Join-Path $modelsRoot $model
+        $modelfilePath = Join-Path $modelFolder "Modelfile"
+
+        # Create folder if missing
+        if (-Not (Test-Path $modelFolder)) {
+            New-Item -ItemType Directory -Path $modelFolder | Out-Null
+        }
+
+        # Create Modelfile if missing
+        if (-Not (Test-Path $modelfilePath)) {
+            $content = "FROM $model`r`n`r`n$defaultParams"
+            Set-Content -Path $modelfilePath -Value $content
+            Add-Content $logFile "[$(Get-Date)] Created Modelfile for $model"
+        } else {
+            Add-Content $logFile "[$(Get-Date)] Modelfile already exists for $model, skipping creation"
+        }
+
+        # Register model
+        Write-Host "Registering $model..."
+        $result = & ollama create $model -f $modelfilePath 2>&1
+
+        if ($LASTEXITCODE -eq 0) {
+            Add-Content $logFile "[$(Get-Date)] Successfully registered $model"
+        } else {
+            Add-Content $logFile "[$(Get-Date)] ERROR registering $model: $result"
+        }
+    }
+    catch {
+        $errorMsg = $_.Exception.Message
+        Add-Content $logFile "[$(Get-Date)] EXCEPTION for $model: $errorMsg"
+        Write-Host "Error processing $model: $errorMsg"
+    }
+}
+
+Write-Host "Done! Check the log file at: $logFile"

--- a/tools/ollama/convert-models-to-ui.ps1
+++ b/tools/ollama/convert-models-to-ui.ps1
@@ -17,6 +17,12 @@ TEMPLATE """
 # Start logging
 "=== Ollama Model Registration Log ===" | Out-File $logFile
 
+# Check if manifests directory exists
+if (-Not (Test-Path $manifestPath)) {
+    Write-Host "Manifests directory not found at: $manifestPath"
+    exit 1
+}
+
 # Get all model names from manifests
 $modelNames = Get-ChildItem -Path $manifestPath -File | ForEach-Object {
     $_.BaseName


### PR DESCRIPTION
This pull request introduces a new PowerShell script to automate the registration of Ollama models by creating missing `Modelfile`s and logging the process. The script scans for available models, ensures each has a configuration file, registers them with Ollama, and logs all actions and errors for auditing.

Automation of Ollama model registration:

* Added `convert-models-to-ui.ps1` script to automate the creation of `Modelfile`s for each model found in the manifests directory and register them with Ollama.
* The script creates a log file (`model_registration.log`) to record successful registrations, skipped models, and any errors encountered during processing.
* Default parameters and template content for new `Modelfile`s are included to standardize model configuration.
* Robust error handling is implemented to ensure exceptions are logged and displayed, improving reliability and traceability.